### PR TITLE
Handle creating toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # feature-toggle-performance-tests
 
+## Running
+```bash
+$ ./gradlew gatlingRun-uk.gov.hmcts.reform.featuretoggle.MainSimulation
+```
+
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/src/gatling/resources/conf/application.conf
+++ b/src/gatling/resources/conf/application.conf
@@ -1,0 +1,8 @@
+baseUrl = "http://localhost:8580"
+baseUrl = ${?BASE_URL}
+
+username = "admin"
+username = ${?USERNAME}
+
+password = "admin"
+password = ${?PASSWORD}

--- a/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/MainSimulation.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/MainSimulation.scala
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.featuretoggle
+
+import com.typesafe.config.{Config, ConfigFactory}
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import uk.gov.hmcts.reform.featuretoggle.actions.Create.createToggle
+
+import scala.concurrent.duration._
+
+class MainSimulation extends Simulation {
+
+  val config: Config = ConfigFactory.load()
+
+  setUp(
+    scenario("Main scenario")
+      .during(1.minutes)(
+        exec(
+          createToggle
+          pause(1.seconds, 2.seconds)
+        )
+      )
+      .inject(
+        rampUsers(100).over(10.seconds)
+      )
+  ).protocols(http.baseURL(config.getString("baseUrl")))
+}

--- a/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/Create.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/Create.scala
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.featuretoggle.actions
+
+
+import java.util.UUID
+
+import com.typesafe.config.{Config, ConfigFactory}
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
+import io.gatling.http.Predef._
+
+object Create {
+
+  private val config: Config = ConfigFactory.load()
+  private val uidFeeder = Iterator.continually(Map("uid" -> ("perf-test-" + UUID.randomUUID.toString)))
+
+  val createToggle: ChainBuilder =
+    feed(uidFeeder)
+      .exec(
+        http("Create toggle")
+          .put("/api/ff4j/store/features/${uid}")
+          .asJSON
+          .basicAuth(
+            config.getString("username"),
+            config.getString("password")
+          )
+          .body(
+            StringBody(
+              """
+                |{
+                |  "uid": "${uid}",
+                |  "description": "Feature toggle for performance test",
+                |  "enable": true
+                |}
+              """.stripMargin
+            )
+          )
+          .check(
+            status.is(201)
+          )
+      )
+}


### PR DESCRIPTION
This PR adds config and code for creating toggles in the api.  
Test can also be run, but it only creates toggles (for now).

The plan is to create toggles in setup stage, then stress the api with reads and finally remove the toggles.