### PR TITLE
Read toggles

### DIFF
--- a/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/MainSimulation.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/MainSimulation.scala
@@ -4,6 +4,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import uk.gov.hmcts.reform.featuretoggle.actions.Create.createToggle
+import uk.gov.hmcts.reform.featuretoggle.actions.Read.readToggle
 
 import scala.concurrent.duration._
 
@@ -12,14 +13,20 @@ class MainSimulation extends Simulation {
   val config: Config = ConfigFactory.load()
 
   setUp(
-    scenario("Main scenario")
+    scenario("Create toggles")
+      .repeat(100) {
+        exec(createToggle)
+      }
+      .inject(atOnceUsers(1)),
+    scenario("Read toggles")
       .during(1.minutes)(
         exec(
-          createToggle
-          pause(1.seconds, 2.seconds)
+          readToggle
+            pause(1.seconds, 2.seconds)
         )
       )
       .inject(
+        nothingFor(10.seconds), // wait fro previous scenario to end
         rampUsers(100).over(10.seconds)
       )
   ).protocols(http.baseURL(config.getString("baseUrl")))

--- a/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/MainSimulation.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/MainSimulation.scala
@@ -22,7 +22,7 @@ class MainSimulation extends Simulation {
       .during(1.minutes)(
         exec(
           readToggle
-            pause(1.seconds, 2.seconds)
+          pause(1.seconds, 2.seconds)
         )
       )
       .inject(

--- a/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/Create.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/Create.scala
@@ -1,17 +1,16 @@
 package uk.gov.hmcts.reform.featuretoggle.actions
 
 
-import java.util.UUID
-
 import com.typesafe.config.{Config, ConfigFactory}
 import io.gatling.core.Predef._
 import io.gatling.core.structure.ChainBuilder
 import io.gatling.http.Predef._
+import uk.gov.hmcts.reform.featuretoggle.actions.util.ToggleIdStore
 
 object Create {
 
   private val config: Config = ConfigFactory.load()
-  private val uidFeeder = Iterator.continually(Map("uid" -> ("perf-test-" + UUID.randomUUID.toString)))
+  private val uidFeeder = Iterator.continually(Map("uid" -> ToggleIdStore.addRandom()))
 
   val createToggle: ChainBuilder =
     feed(uidFeeder)

--- a/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/Read.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/Read.scala
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.featuretoggle.actions
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ChainBuilder
+import io.gatling.http.Predef._
+import uk.gov.hmcts.reform.featuretoggle.actions.util.ToggleIdStore
+
+object Read {
+
+  private val uidFeeder = Iterator.continually(Map("uid" -> ToggleIdStore.getRandom()))
+
+  val readToggle: ChainBuilder =
+    feed(uidFeeder)
+      .exec(
+        http("Read toggle")
+          .get("/api/ff4j/store/features/${uid}")
+          .asJSON
+          .check(
+            status.is(200)
+          )
+      )
+}

--- a/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/util/ToggleIdStore.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/util/ToggleIdStore.scala
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.reform.featuretoggle.actions.util
+
+import java.util.UUID
+
+import scala.collection.mutable
+import scala.util.Random
+
+object ToggleIdStore {
+
+  private val ids = mutable.SortedSet[String]()
+
+  def addRandom() = {
+    val id = "perf-test-" + UUID.randomUUID.toString
+    ids.add(id)
+    id
+  }
+  def getRandom() = ids.toVector((new Random).nextInt(ids.size))
+}

--- a/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/util/ToggleIdStore.scala
+++ b/src/gatling/scala/uk/gov/hmcts/reform/featuretoggle/actions/util/ToggleIdStore.scala
@@ -7,12 +7,14 @@ import scala.util.Random
 
 object ToggleIdStore {
 
-  private val ids = mutable.SortedSet[String]()
+  private val ids = mutable.MutableList[String]()
 
   def addRandom() = {
     val id = "perf-test-" + UUID.randomUUID.toString
-    ids.add(id)
+    ids += id
+
     id
   }
-  def getRandom() = ids.toVector((new Random).nextInt(ids.size))
+
+  def getRandom() = ids((new Random).nextInt(ids.size))
 }


### PR DESCRIPTION
Added a separate stage in which toggles are created and their IDs saved for later.
Next, GET calls are being sent using the IDs saved in previous stage.

Still todo on future PRs:
- cleanup toggles after test is over
- make duration, number of toggles etc configurable via env vars